### PR TITLE
adds a flag in disputer to check if bot needs to call withdrawLiquida…

### DIFF
--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -236,7 +236,10 @@ class Disputer {
     // Sumero-fix: WITHDRAW_ALL_LIQUIDATIONS instructs the bot if bot need to trigger withdrawLiquidation for other users
     // Currently Sumero doesn't support for users to call withdrawLiquidation from UI.
     const shouldWithdrawAll = process.env.WITHDRAW_ALL_LIQUIDATIONS;
-    if (!(shouldWithdrawAll !== "0" && shouldWithdrawAll !== "false" && !!shouldWithdrawAll)) {
+    if (shouldWithdrawAll !== "0" && shouldWithdrawAll !== "false" && !!shouldWithdrawAll) {
+      this.logger.info({ at: "Disputer", message: "Calling withdrawLiquidation for all users 🥁" });
+    } else {
+      // Here the bot will just call withdrawLiquidation for the disputes that were created by bot only
       disputedLiquidations = disputedLiquidations.filter((liquidation) => liquidation.disputer === disputerAddress);
     }
 

--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -231,13 +231,14 @@ class Disputer {
       : this.account;
 
     // Can only derive rewards from disputed liquidations that this account disputed.
-    const disputedLiquidations = this.financialContractClient.getDisputedLiquidations().filter((liquidation) => {
-      // Sumero-fix: WITHDRAW_ALL_LIQUIDATIONS instructs the bot if bot need to trigger withdrawLiquidation for other users
-      // Currently Sumero doesn't support for users to call withdrawLiquidation from UI.
-      const shouldWithdrawAll = process.env.WITHDRAW_ALL_LIQUIDATIONS;
-      if (shouldWithdrawAll !== "0" && shouldWithdrawAll !== "false" && !!shouldWithdrawAll) return true;
-      return liquidation.disputer === disputerAddress;
-    });
+    let disputedLiquidations = this.financialContractClient.getDisputedLiquidations();
+
+    // Sumero-fix: WITHDRAW_ALL_LIQUIDATIONS instructs the bot if bot need to trigger withdrawLiquidation for other users
+    // Currently Sumero doesn't support for users to call withdrawLiquidation from UI.
+    const shouldWithdrawAll = process.env.WITHDRAW_ALL_LIQUIDATIONS;
+    if (!(shouldWithdrawAll !== "0" && shouldWithdrawAll !== "false" && !!shouldWithdrawAll)) {
+      disputedLiquidations = disputedLiquidations.filter((liquidation) => liquidation.disputer === disputerAddress);
+    }
 
     if (disputedLiquidations.length === 0) {
       this.logger.debug({ at: "Disputer", message: "No withdrawable disputes" });

--- a/packages/disputer/src/disputer.js
+++ b/packages/disputer/src/disputer.js
@@ -231,9 +231,13 @@ class Disputer {
       : this.account;
 
     // Can only derive rewards from disputed liquidations that this account disputed.
-    const disputedLiquidations = this.financialContractClient
-      .getDisputedLiquidations()
-      .filter((liquidation) => liquidation.disputer === disputerAddress);
+    const disputedLiquidations = this.financialContractClient.getDisputedLiquidations().filter((liquidation) => {
+      // Sumero-fix: WITHDRAW_ALL_LIQUIDATIONS instructs the bot if bot need to trigger withdrawLiquidation for other users
+      // Currently Sumero doesn't support for users to call withdrawLiquidation from UI.
+      const shouldWithdrawAll = process.env.WITHDRAW_ALL_LIQUIDATIONS;
+      if (shouldWithdrawAll !== "0" && shouldWithdrawAll !== "false" && !!shouldWithdrawAll) return true;
+      return liquidation.disputer === disputerAddress;
+    });
 
     if (disputedLiquidations.length === 0) {
       this.logger.debug({ at: "Disputer", message: "No withdrawable disputes" });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

<!--
  Title
  Please include a concise title that briefly describes the change.
  Titles should follow https://www.conventionalcommits.org/.
  They should also be in the present simple tense.

  Examples:

  feat(dvm): adds a new function to compute voting rewards offchain
  fix(monitor): fixes broken link in liquidation log
  feat(voter-dapp): adds countdown timer component to the header
  build(solc): updates solc version to 0.6.12
  improve(emp-client): parallelizes web3 calls to improve performance

  For examples of other types (feat, fix, build, improve) and what they mean, take a look at the angular list:
  https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

  See https://github.com/UMAprotocol/protocol/blob/master/CONTRIBUTING.md#conventional-commits for more details on PR
  title expectations.
-->


**Summary**

Currently Sumero has support for the users to dispute a liquidation but users can't call withdrawLiquidation from UI.
For now we have added a flag in bot, using which we can instruct the bot if it has to call withdrawLiquidation for other users.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [ ]  All existing tests pass
- [x]  Untested
